### PR TITLE
Trim whitespace from value to avoid conditional false negative. Fixes craftcms/redactor#377

### DIFF
--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -91,7 +91,7 @@ abstract class HtmlField extends Field
             return $value;
         }
 
-        if (in_array($value, ['<p><br></p>', '<p>&nbsp;</p>'], true)) {
+        if (in_array(trim($value), ['<p><br></p>', '<p>&nbsp;</p>'], true)) {
             return null;
         }
 


### PR DESCRIPTION
### Description

Under certain circumstances, the value returned by the front end editor (e.g. Redactor) can include trailing whitespace (see craftcms/redactor#377). This whitespace will cause a false negative in a conditional testing for empty HTML tags when normalizing the field value – which ends in the field value being saved as a string of empty tags, rather than the `null` we want.

This PR fixes this issue by making sure the field value is trimmed for leading/trailing whitespace before testing it for empty tags inside the `normalizeValue()` method.
### Related issues

craftcms/redactor#377