### PR TITLE
add isEmpty method

### DIFF
--- a/src/HtmlFieldData.php
+++ b/src/HtmlFieldData.php
@@ -59,4 +59,14 @@ class HtmlFieldData extends Markup
     {
         return (string)$this;
     }
+
+    /**
+     * Returns whether the content of the field is empty or not.
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return strlen(trim($this->getParsedContent())) === 0;
+    }
 }


### PR DESCRIPTION
### Description
Adds the `isEmpty()` method to the `HtmlFieldData` class so that `EmptyFieldConditionRule` can work as expected.

There’s a related PR in the cms repo: https://github.com/craftcms/cms/pull/15381.


### Related issues
[#267](https://github.com/craftcms/ckeditor/issues/267)
