### PR TITLE
add the query to the parsed URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "prefer-stable": true,
   "require": {
     "php": "^8.2",
-    "craftcms/cms": "^5.0.0-beta.1",
+    "craftcms/cms": "^5.5.0",
     "league/html-to-markdown": "^5.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "485a3c3a501f026dba5b5d089ecb923f",
+    "content-hash": "c89064cd20051ed652405585c53bd61d",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -331,16 +331,16 @@
         },
         {
             "name": "craftcms/cms",
-            "version": "5.4.7.1",
+            "version": "5.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craftcms/cms.git",
-                "reference": "7f26db4a36c374117c281707a22b5493335e042b"
+                "reference": "3ff575a4c8921d2c43a700e9e1f9f98014c379e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/cms/zipball/7f26db4a36c374117c281707a22b5493335e042b",
-                "reference": "7f26db4a36c374117c281707a22b5493335e042b",
+                "url": "https://api.github.com/repos/craftcms/cms/zipball/3ff575a4c8921d2c43a700e9e1f9f98014c379e6",
+                "reference": "3ff575a4c8921d2c43a700e9e1f9f98014c379e6",
                 "shasum": ""
             },
             "require": {
@@ -364,6 +364,7 @@
                 "ext-zip": "*",
                 "guzzlehttp/guzzle": "^7.2.0",
                 "illuminate/collections": "^v10.42.0",
+                "league/uri": "^7.0",
                 "mikehaertl/php-shellcommand": "^1.6.3",
                 "moneyphp/money": "^4.0",
                 "monolog/monolog": "^3.0",
@@ -453,7 +454,7 @@
                 "rss": "https://github.com/craftcms/cms/releases.atom",
                 "source": "https://github.com/craftcms/cms"
             },
-            "time": "2024-10-09T08:30:12+00:00"
+            "time": "2025-01-15T00:23:37+00:00"
         },
         {
             "name": "craftcms/plugin-installer",
@@ -1809,6 +1810,180 @@
                 }
             ],
             "time": "2023-07-12T21:21:09+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
+                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.5",
+                "php": "^8.1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
+                "league/uri-components": "Needed to easily manipulate URI objects components",
+                "php-64bit": "to improve IPV4 host parsing",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-08T08:40:02+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-factory": "^1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common interfaces and classes for URI representation and interaction",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-08T08:18:47+00:00"
         },
         {
             "name": "mikehaertl/php-shellcommand",
@@ -7374,5 +7549,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -260,7 +260,7 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
                         // Decode any HTML entities, e.g. &amp;
                         $query = Html::decode($query);
                         // split the query into parts
-                        $queryParts = explode('&', $query);
+                        $queryParts = explode('&', ltrim($query, '?'));
                         foreach ($queryParts as $key => $queryPart) {
                             // if the $queryPart is a part of the parsed url, update the URL
                             // otherwise, we'll add it after the ref ({} portion of the URL)

--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -283,7 +283,7 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
                         if (mb_strpos($parsed, $hash) !== false) {
                             $url .= $hash;
                             $hash = '';
-                        } else if (mb_strpos($parsed, '#') !== false) {
+                        } elseif (mb_strpos($parsed, '#') !== false) {
                             // if the $parsed URL has a hash, use it and discard the "new" hash
                             try {
                                 $uri = Uri::new($parsed);

--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -22,6 +22,7 @@ use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
 use craft\validators\HandleValidator;
 use HTMLPurifier_Config;
+use League\Uri\Uri;
 
 /**
  * Base HTML Field
@@ -258,14 +259,44 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
                     if ($query) {
                         // Decode any HTML entities, e.g. &amp;
                         $query = Html::decode($query);
-                        if (mb_strpos($parsed, $query) !== false) {
-                            $url .= $query;
+                        // split the query into parts
+                        $queryParts = explode('&', $query);
+                        foreach ($queryParts as $key => $queryPart) {
+                            // if the $queryPart is a part of the parsed url, update the URL
+                            // otherwise, we'll add it after the ref ({} portion of the URL)
+                            if (mb_strpos($parsed, $queryPart) !== false) {
+                                $url = UrlHelper::urlWithParams($url, $queryPart);
+                                unset($queryParts[$key]);
+                            }
+                        }
+                        $queryParts = array_values($queryParts);
+                        if (empty($queryParts)) {
                             $query = '';
+                        } else {
+                            $query = '?' . implode('&', $queryParts);
                         }
                     }
-                    if ($hash && mb_strpos($parsed, $hash) !== false) {
-                        $url .= $hash;
-                        $hash = '';
+
+                    // if we have a $hash
+                    if ($hash) {
+                        // and there's a hash in the $parsed URL, and they match - add $hash to the $url and empty $hash
+                        if (mb_strpos($parsed, $hash) !== false) {
+                            $url .= $hash;
+                            $hash = '';
+                        } else if (mb_strpos($parsed, '#') !== false) {
+                            // if the $parsed URL has a hash, use it and discard the "new" hash
+                            try {
+                                $uri = Uri::new($parsed);
+                                $hash = $uri->getFragment();
+                                if ($hash) {
+                                    $url .= '#' . $hash;
+                                }
+                            } catch (\Exception $e) {
+                                // oh, well
+                            }
+                            $hash = '';
+                        }
+                        // otherwise, use that new hash
                     }
                 }
 
@@ -405,6 +436,7 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
                 if ($query) {
                     // Decode any HTML entities, e.g. &amp;
                     $query = Html::decode($query);
+                    // we want to keep the whole query, regardless of whether it's part of the element's URI format or not
                     $parsed = UrlHelper::urlWithParams($parsed, $query);
                 }
 

--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -405,9 +405,7 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
                 if ($query) {
                     // Decode any HTML entities, e.g. &amp;
                     $query = Html::decode($query);
-                    if (mb_strpos($parsed, $query) !== false) {
-                        $parsed = UrlHelper::urlWithParams($parsed, $query);
-                    }
+                    $parsed = UrlHelper::urlWithParams($parsed, $query);
                 }
 
                 // Make sure the ref handle matches the real ref handle from the resolved element type


### PR DESCRIPTION
### Description
Don’t lose the query string when parsing refs.


### Related issues
[PT-2002](https://linear.app/craftcms/issue/PT-2002/updated-link-modal)
