### PR TITLE
when searching for asset based on folder path, ensure path ends with a slash

### DIFF
--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -357,7 +357,7 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
                             $assetId = Asset::find()
                                 ->volumeId($volumeIds[$key])
                                 ->filename($filename)
-                                ->folderPath($folderPath !== '.' ? $folderPath : '')
+                                ->folderPath($folderPath !== '.' ? StringHelper::ensureRight($folderPath, '/') : '')
                                 ->select(['elements.id'])
                                 ->scalar();
 


### PR DESCRIPTION
### Description
When serialising a field’s value and searching for an asset by folder path, the path needs to end with a slash, or the query won’t find it, even if it exists.


### Related issues
[cke#448](https://github.com/craftcms/ckeditor/issues/448)
