### PR TITLE
toPlainText - decode html entities

### DIFF
--- a/src/HtmlFieldData.php
+++ b/src/HtmlFieldData.php
@@ -121,7 +121,7 @@ class HtmlFieldData extends Markup
             'hard_break' => true,
         ]);
 
-        return $converter->convert($body->html());
+        return html_entity_decode($converter->convert($body->html()));
     }
 
     protected string $rawContent;


### PR DESCRIPTION
### Description
`toPlainText()` method should decode html entities


### Related issues
https://github.com/craftcms/ckeditor/issues/535
