### PR TITLE
update _parseRefs and serializeValue so that it works with alt attribute

### DIFF
--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -435,8 +435,26 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
 
         $elementsService = Craft::$app->getElements();
 
+        // Parse alt attribute asset ref tags: {asset:123:alt||fallback text}
+        $value = preg_replace_callback(
+            '/(alt=)([\'"])(\{asset:(\d+(?:@\d+)?):alt(?:\|\|[^\}]+)?\})\2/',
+            function($matches) use ($element) {
+                [$fullMatch, $attr, $q, $refTag, $ref] = $matches;
+                $parsed = Craft::$app->getElements()->parseRefs($refTag, $element->siteId ?? null);
+
+                // If the ref tag couldn't be resolved, leave it alone
+                if ($parsed === $refTag) {
+                    return $fullMatch;
+                }
+
+                // Output: alt="[resolved text]#asset:123:alt"
+                return $attr . $q . $parsed . '#asset:' . $ref . ':alt' . $q;
+            },
+            $value
+        );
+
         return preg_replace_callback(
-            sprintf('/(href=|src=|alt=)([\'"])(\{([\w\\\\]+)(\:\d+(?:@\d+)?\:(?:transform\:)?%s)(?:\|\|[^\}]+)?\})(?:\?([^\'"#]*))?(#[^\'"#]+)?\2/', HandleValidator::$handlePattern),
+            sprintf('/(href=|src=)([\'"])(\{([\w\\\\]+)(\:\d+(?:@\d+)?\:(?:transform\:)?%s)(?:\|\|[^\}]+)?\})(?:\?([^\'"#]*))?(#[^\'"#]+)?\2/', HandleValidator::$handlePattern),
             function($matches) use ($element, $elementsService) {
                 [$fullMatch, $attr, $q, $refTag, $refHandle, $refRemainder, $query, $fragment] = array_pad($matches, 8, null);
                 $parsed = Craft::$app->getElements()->parseRefs($refTag, $element->siteId ?? null);

--- a/src/HtmlField.php
+++ b/src/HtmlField.php
@@ -242,6 +242,19 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
             $value = preg_replace('/  +/', ' ', $value);
         }
 
+        // Find any alt text element refs and swap them with ref tags
+        $value = preg_replace_callback(
+            '/(alt=)([\'"])([^\'"]*)(?:#|%%23)asset:(\d+)(?:@(\d+))?:alt\2/',
+            function($matches) {
+                [, $attr, $q, $text, $ref, $siteId] = array_pad($matches, 6, null);
+
+                $ref = "asset:$ref" . ($siteId ? "@$siteId" : '') . ':alt';
+
+                return sprintf('%s%s%s', "$attr$q{", "$ref||$text", "}$q");
+            },
+            $value
+        );
+
         // Find any element URLs and swap them with ref tags
         $value = preg_replace_callback(
             sprintf('/(href=|src=)([\'"])([^\'"\?#]*)(\?[^\'"\?#]+)?(#[^\'"\?#]+)?(?:#|%%23)([\w\\\\]+)\:(\d+)(?:@(\d+))?(\:(?:transform\:)?%s)?\2/', HandleValidator::$handlePattern),
@@ -423,7 +436,7 @@ abstract class HtmlField extends Field implements PreviewableFieldInterface
         $elementsService = Craft::$app->getElements();
 
         return preg_replace_callback(
-            sprintf('/(href=|src=)([\'"])(\{([\w\\\\]+)(\:\d+(?:@\d+)?\:(?:transform\:)?%s)(?:\|\|[^\}]+)?\})(?:\?([^\'"#]*))?(#[^\'"#]+)?\2/', HandleValidator::$handlePattern),
+            sprintf('/(href=|src=|alt=)([\'"])(\{([\w\\\\]+)(\:\d+(?:@\d+)?\:(?:transform\:)?%s)(?:\|\|[^\}]+)?\})(?:\?([^\'"#]*))?(#[^\'"#]+)?\2/', HandleValidator::$handlePattern),
             function($matches) use ($element, $elementsService) {
                 [$fullMatch, $attr, $q, $refTag, $refHandle, $refRemainder, $query, $fragment] = array_pad($matches, 8, null);
                 $parsed = Craft::$app->getElements()->parseRefs($refTag, $element->siteId ?? null);


### PR DESCRIPTION
### Description
This PR updates the `_parseRefs` and `serializeValue` methods, to make them work with an `alt` attribute.


### Related issues
https://github.com/craftcms/ckeditor/issues/563
